### PR TITLE
Wrap the schema property type in a try..catch to prevent API 500 errors

### DIFF
--- a/filter-parser.js
+++ b/filter-parser.js
@@ -9,10 +9,14 @@ function createFilterParser(schema) {
         , ignoredTypes = [ Object, Array ]
         , type = null
 
-      if (parentKey) {
-        type = schema.schema[parentKey].type
-      } else {
-        type = schema.schema[key].type
+      try {
+        if (parentKey) {
+          type = schema.schema[parentKey].type
+        } else {
+          type = schema.schema[key].type
+        }
+      } catch(e) {
+        return
       }
 
       // Skip ignored types and Schemata Arrays

--- a/test/filter-parser.test.js
+++ b/test/filter-parser.test.js
@@ -66,6 +66,22 @@ describe('filter parser', function () {
     assert.equal(null, params.number)
   })
 
+  it('should not error on unknown property', function () {
+    assert.doesNotThrow(function () {
+      filterParser({ unknown: 'this should not error' })
+    })
+  })
+
+  it('should not error on unknown nested property', function () {
+    assert.doesNotThrow(function () {
+      filterParser({ string: { unknown: { string: 'this should not error'} } })
+    })
+  })
+
+  it('should strip unknown properties', function () {
+    assert.deepEqual(filterParser({ unknown: 'this should not error' }), {})
+  })
+
 })
 
 function createSchema() {


### PR DESCRIPTION
I accidentally performed a search from the CMS with a malformed filter object of
`{ _id: { $in: model }` which threw a 500 from the API. This adds some error handling.

Not sure what to do with the error at that point as we don't have a logger or much else to do