### PR TITLE
Turn api builder into an event emitter for easy extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ var crudServiceApiBuilder = require('cf-crud-service-api-builder')
 crudServiceApiBuilder(service, '/widgets', router, logger, middleware)
 ```
 
+### Events
+
+When using the api builder, you can listen for certain events so that you can add hooks to perform your own actions after a request has been succesful. e.g
+
+```js
+
+var api = crudServiceApiBuilder(service, '/article', router, logger, middleware)
+
+api.on('create', function (req, newArticle) {
+  // do whatever you like with the req and article object
+})
+
+```
+
+Supported events are:
+
+* `create`
+* `update`
+* `partialUpdate`
+* `delete`
+
 ## Credits
 Built by developers at [Clock](http://clock.co.uk).
 

--- a/api-builder.js
+++ b/api-builder.js
@@ -1,14 +1,17 @@
 module.exports = buildApi
 
 var routes =
-  { get: require('./endpoints/get')
-  , post: require('./endpoints/post')
-  , put: require('./endpoints/put')
-  , patch: require('./endpoints/patch')
-  , 'delete': require('./endpoints/delete')
-  }
+      { get: require('./endpoints/get')
+      , post: require('./endpoints/post')
+      , put: require('./endpoints/put')
+      , patch: require('./endpoints/patch')
+      , 'delete': require('./endpoints/delete')
+      }
+  , EventEmitter = require('events').EventEmitter
 
 function buildApi(service, urlRoot, router, logger, middleware, verbs) {
+
+  var apiBuilder = new EventEmitter()
 
   if (!Array.isArray(middleware) && typeof middleware !== 'function') throw new Error('Middleware is not defined')
 
@@ -17,7 +20,9 @@ function buildApi(service, urlRoot, router, logger, middleware, verbs) {
 
   // Create endpoints
   verbs.forEach(function (verb) {
-    routes[verb](service, urlRoot, router, logger, middleware)
+    routes[verb](service, urlRoot, router, logger, middleware, apiBuilder.emit.bind(apiBuilder))
   })
+
+  return apiBuilder
 
 }

--- a/api-builder.js
+++ b/api-builder.js
@@ -11,7 +11,7 @@ var routes =
 
 function buildApi(service, urlRoot, router, logger, middleware, verbs) {
 
-  var apiBuilder = new EventEmitter()
+  var api = new EventEmitter()
 
   if (!Array.isArray(middleware) && typeof middleware !== 'function') throw new Error('Middleware is not defined')
 
@@ -20,9 +20,9 @@ function buildApi(service, urlRoot, router, logger, middleware, verbs) {
 
   // Create endpoints
   verbs.forEach(function (verb) {
-    routes[verb](service, urlRoot, router, logger, middleware, apiBuilder.emit.bind(apiBuilder))
+    routes[verb](service, urlRoot, router, logger, middleware, api.emit.bind(api))
   })
 
-  return apiBuilder
+  return api
 
 }

--- a/api-builder.js
+++ b/api-builder.js
@@ -11,7 +11,10 @@ var routes =
 
 function buildApi(service, urlRoot, router, logger, middleware, verbs) {
 
-  var api = new EventEmitter()
+  function Api() { EventEmitter.call(this) }
+  Api.prototype = Object.create(EventEmitter.prototype)
+
+  var api = new Api()
 
   if (!Array.isArray(middleware) && typeof middleware !== 'function') throw new Error('Middleware is not defined')
 

--- a/endpoints/delete.js
+++ b/endpoints/delete.js
@@ -12,7 +12,7 @@ function del(service, urlRoot, router, logger, middleware, emit) {
           res.status(400).json(error)
         }
       } else {
-        emit('DELETE', req)
+        emit('delete', req)
         res.send(204)
       }
     })

--- a/endpoints/delete.js
+++ b/endpoints/delete.js
@@ -1,6 +1,6 @@
 module.exports = del
 
-function del(service, urlRoot, router, logger, middleware) {
+function del(service, urlRoot, router, logger, middleware, emit) {
 
   router.delete(urlRoot + '/:id', middleware, function (req, res) {
     logger.debug('DELETE received', req.params.id)
@@ -12,6 +12,7 @@ function del(service, urlRoot, router, logger, middleware) {
           res.status(400).json(error)
         }
       } else {
+        emit('DELETE', req)
         res.send(204)
       }
     })

--- a/endpoints/patch.js
+++ b/endpoints/patch.js
@@ -9,7 +9,7 @@ function patch(service, urlRoot, router, logger, middleware, emit) {
       if (error) {
         res.status(400).json(error)
       } else {
-        emit('patch', req, updatedObject)
+        emit('partialUpdate', req, updatedObject)
         res.status(200).json(updatedObject)
       }
     })

--- a/endpoints/patch.js
+++ b/endpoints/patch.js
@@ -1,6 +1,6 @@
 module.exports = patch
 
-function patch(service, urlRoot, router, logger, middleware) {
+function patch(service, urlRoot, router, logger, middleware, emit) {
 
   router.patch(urlRoot + '/:id', middleware, function (req, res) {
     logger.debug('PATCH received', JSON.stringify(req.body))
@@ -9,6 +9,7 @@ function patch(service, urlRoot, router, logger, middleware) {
       if (error) {
         res.status(400).json(error)
       } else {
+        emit('PATCH', req, updatedObject)
         res.status(200).json(updatedObject)
       }
     })

--- a/endpoints/patch.js
+++ b/endpoints/patch.js
@@ -9,7 +9,7 @@ function patch(service, urlRoot, router, logger, middleware, emit) {
       if (error) {
         res.status(400).json(error)
       } else {
-        emit('PATCH', req, updatedObject)
+        emit('patch', req, updatedObject)
         res.status(200).json(updatedObject)
       }
     })

--- a/endpoints/post.js
+++ b/endpoints/post.js
@@ -8,7 +8,7 @@ function post(service, urlRoot, router, logger, middleware, emit) {
       if (error) {
         res.status(400).json(error)
       } else {
-        emit('POST', req, newObject)
+        emit('post', req, newObject)
         res.status(201).json(newObject)
       }
     })

--- a/endpoints/post.js
+++ b/endpoints/post.js
@@ -8,7 +8,7 @@ function post(service, urlRoot, router, logger, middleware, emit) {
       if (error) {
         res.status(400).json(error)
       } else {
-        emit('post', req, newObject)
+        emit('create', req, newObject)
         res.status(201).json(newObject)
       }
     })

--- a/endpoints/post.js
+++ b/endpoints/post.js
@@ -1,6 +1,6 @@
 module.exports = post
 
-function post(service, urlRoot, router, logger, middleware) {
+function post(service, urlRoot, router, logger, middleware, emit) {
 
   router.post(urlRoot, middleware, function (req, res) {
     logger.debug('POST received', JSON.stringify(req.body))
@@ -8,6 +8,7 @@ function post(service, urlRoot, router, logger, middleware) {
       if (error) {
         res.status(400).json(error)
       } else {
+        emit('POST', req, newObject)
         res.status(201).json(newObject)
       }
     })

--- a/endpoints/put.js
+++ b/endpoints/put.js
@@ -31,7 +31,7 @@ function put(service, urlRoot, router, logger, middleware, emit) {
           }
           cb(null, error)
         } else {
-          emit('put', req, updatedObject)
+          emit('update', req, updatedObject)
           cb(null, updatedObject)
         }
       })

--- a/endpoints/put.js
+++ b/endpoints/put.js
@@ -31,7 +31,7 @@ function put(service, urlRoot, router, logger, middleware, emit) {
           }
           cb(null, error)
         } else {
-          emit('PUT', req, updatedObject)
+          emit('put', req, updatedObject)
           cb(null, updatedObject)
         }
       })

--- a/endpoints/put.js
+++ b/endpoints/put.js
@@ -3,7 +3,7 @@ module.exports = put
 var async = require('async')
   , extend = require('lodash.assign')
 
-function put(service, urlRoot, router, logger, middleware) {
+function put(service, urlRoot, router, logger, middleware, emit) {
 
   // Optional :id url param to allow for arrays to be PUT
   router.put(urlRoot + '/:id?', middleware, function (req, res) {
@@ -31,6 +31,7 @@ function put(service, urlRoot, router, logger, middleware) {
           }
           cb(null, error)
         } else {
+          emit('PUT', req, updatedObject)
           cb(null, updatedObject)
         }
       })

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^3.18.4",
     "istanbul": "0",
     "jshint": "2",
+    "mc-logger": "0.0.0",
     "mocha": "1",
     "save": "0.0.20",
     "schemata": "^2.0.2",

--- a/test/endpoints/get.test.js
+++ b/test/endpoints/get.test.js
@@ -2,13 +2,11 @@ var createGetEndpoint = require('../../endpoints/get')
   , express = require('express')
   , createService = require('../service')
   , request = require('supertest')
-  , logger = { debug: noop, info: noop, warn: noop, error: noop }
+  , logger = require('mc-logger')
   , assert = require('assert')
   , async = require('async')
   , extend = require('lodash.assign')
   , qs = require('querystring')
-
-function noop() {}
 
 describe('GET endpoint', function () {
 

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,0 +1,99 @@
+var assert = require('assert')
+  , crudServiceApiBuilder = require('../api-builder')
+  , express = require('express')
+  , logger = require('mc-logger')
+  , request = require('supertest')
+  , service = require('./service')()
+  , app = express()
+
+app.use(express.json())
+
+describe('events', function () {
+
+  var apiBuilder = null
+
+  before(function () {
+    apiBuilder = crudServiceApiBuilder(service, '/things', app, logger, [], null)
+  })
+
+  it('should be emitted after a POST', function (done) {
+
+    var eventFired = false
+    apiBuilder.on('POST', function (req, data) {
+      eventFired = true
+      assert(req, 'req is not present')
+      assert.equal(data._id, '1')
+    })
+
+    request(app)
+      .post('/things')
+      .set('Accept', 'application/json')
+      .send({})
+      .expect(201)
+      .end(function (error) {
+        if (error) return done(error)
+        assert.equal(eventFired, true, 'POST event was not fired')
+        done()
+      })
+  })
+
+  it('should be emitted after a PUT', function (done) {
+    var eventFired = false
+    apiBuilder.on('PUT', function (req, data) {
+      eventFired = true
+      assert(req, 'req is not present')
+      assert.equal(data._id, '1')
+    })
+
+    request(app)
+      .put('/things/1')
+      .set('Accept', 'application/json')
+      .send({ _id: '1' })
+      .expect(200)
+      .end(function (error) {
+        if (error) return done(error)
+        assert.equal(eventFired, true, 'PUT event was not fired')
+        done()
+      })
+  })
+
+  it('should be emitted after a PATCH', function (done) {
+    var eventFired = false
+    apiBuilder.on('PATCH', function (req, data) {
+      eventFired = true
+      assert(req, 'req is not present')
+      assert.equal(data._id, '1')
+    })
+
+    request(app)
+      .patch('/things/1')
+      .set('Accept', 'application/json')
+      .send({ _id: '1' })
+      .expect(200)
+      .end(function (error) {
+        if (error) return done(error)
+        assert.equal(eventFired, true, 'PATCH event was not fired')
+        done()
+      })
+  })
+
+  it('should be emitted after a DELETE', function (done) {
+    var eventFired = false
+    apiBuilder.on('DELETE', function (req) {
+      eventFired = true
+      assert(req, 'req is not present')
+    })
+
+    request(app)
+      .delete('/things/1')
+      .set('Accept', 'application/json')
+      .send({ _id: '1' })
+      .expect(204)
+      .end(function (error) {
+        if (error) return done(error)
+        assert.equal(eventFired, true, 'DELETE event was not fired')
+        done()
+      })
+  })
+
+})

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -19,7 +19,7 @@ describe('events', function () {
   it('should be emitted after a POST', function (done) {
 
     var eventFired = false
-    apiBuilder.on('post', function (req, data) {
+    apiBuilder.on('create', function (req, data) {
       eventFired = true
       assert(req, 'req is not present')
       assert.equal(data._id, '1')
@@ -32,14 +32,14 @@ describe('events', function () {
       .expect(201)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'post event was not fired')
+        assert.equal(eventFired, true, 'create event was not fired')
         done()
       })
   })
 
   it('should be emitted after a PUT', function (done) {
     var eventFired = false
-    apiBuilder.on('put', function (req, data) {
+    apiBuilder.on('update', function (req, data) {
       eventFired = true
       assert(req, 'req is not present')
       assert.equal(data._id, '1')
@@ -52,14 +52,14 @@ describe('events', function () {
       .expect(200)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'put event was not fired')
+        assert.equal(eventFired, true, 'update event was not fired')
         done()
       })
   })
 
   it('should be emitted after a PATCH', function (done) {
     var eventFired = false
-    apiBuilder.on('patch', function (req, data) {
+    apiBuilder.on('partialUpdate', function (req, data) {
       eventFired = true
       assert(req, 'req is not present')
       assert.equal(data._id, '1')
@@ -72,7 +72,7 @@ describe('events', function () {
       .expect(200)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'patch event was not fired')
+        assert.equal(eventFired, true, 'partialUpdate event was not fired')
         done()
       })
   })

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -19,7 +19,7 @@ describe('events', function () {
   it('should be emitted after a POST', function (done) {
 
     var eventFired = false
-    apiBuilder.on('POST', function (req, data) {
+    apiBuilder.on('post', function (req, data) {
       eventFired = true
       assert(req, 'req is not present')
       assert.equal(data._id, '1')
@@ -32,14 +32,14 @@ describe('events', function () {
       .expect(201)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'POST event was not fired')
+        assert.equal(eventFired, true, 'post event was not fired')
         done()
       })
   })
 
   it('should be emitted after a PUT', function (done) {
     var eventFired = false
-    apiBuilder.on('PUT', function (req, data) {
+    apiBuilder.on('put', function (req, data) {
       eventFired = true
       assert(req, 'req is not present')
       assert.equal(data._id, '1')
@@ -52,14 +52,14 @@ describe('events', function () {
       .expect(200)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'PUT event was not fired')
+        assert.equal(eventFired, true, 'put event was not fired')
         done()
       })
   })
 
   it('should be emitted after a PATCH', function (done) {
     var eventFired = false
-    apiBuilder.on('PATCH', function (req, data) {
+    apiBuilder.on('patch', function (req, data) {
       eventFired = true
       assert(req, 'req is not present')
       assert.equal(data._id, '1')
@@ -72,14 +72,14 @@ describe('events', function () {
       .expect(200)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'PATCH event was not fired')
+        assert.equal(eventFired, true, 'patch event was not fired')
         done()
       })
   })
 
   it('should be emitted after a DELETE', function (done) {
     var eventFired = false
-    apiBuilder.on('DELETE', function (req) {
+    apiBuilder.on('delete', function (req) {
       eventFired = true
       assert(req, 'req is not present')
     })
@@ -91,7 +91,7 @@ describe('events', function () {
       .expect(204)
       .end(function (error) {
         if (error) return done(error)
-        assert.equal(eventFired, true, 'DELETE event was not fired')
+        assert.equal(eventFired, true, 'delete event was not fired')
         done()
       })
   })

--- a/test/service.js
+++ b/test/service.js
@@ -4,9 +4,7 @@ var Service = require('crud-service')
   , save = require('save')
   , schemata = require('schemata')
   , validity = require('validity')
-  , logger = { debug: noop, info: noop, warn: noop, error: noop }
-
-function noop() {}
+  , logger = require('mc-logger')
 
 function createService() {
   return new Service('thing', save('thing', { logger: logger }), createSchema())


### PR DESCRIPTION
Changed the api builder to return an event emitter so that we can hook into the various actions and gain access to req as well as the newly saved data object.

@bengourley @serby would you guys be able to take a look please? Any feedback appreciated.

Changes are backwards compatible, so only a minor version bump needed